### PR TITLE
Fix "openvpn.getLog is not a function"

### DIFF
--- a/lib/openvpn.js
+++ b/lib/openvpn.js
@@ -105,7 +105,7 @@ function OpenVPNManagement(cmd) {
     });
 }
 
-function OpenVPNLog() {
+module.exports.getLog = function() {
     connection.exec('log on all', function(logsResponse) {
         connection.exec('state on', function(logsResponse) {
             connection.on('console-output', function(response) {


### PR DESCRIPTION
There is an error when running "getLog", so this pull request is strictly for fixing this, as it is not defined in the library.